### PR TITLE
fix: do not add extra keys to object

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,12 @@ module.exports = function sortObjectByKeyNameList(object, sortWith) {
   } else {
     keys = sortWith;
   }
-  return (keys || []).concat(Object.keys(object).sort(sortFn)).reduce(function(total, key) {
-    total[key] = object[key];
+
+  var objectKeys = Object.keys(object);
+  return (keys || []).concat(objectKeys.sort(sortFn)).reduce(function(total, key) {
+    if (objectKeys.indexOf(key) !== -1) {
+      total[key] = object[key];
+    }
     return total;
   }, Object.create(null));
 }

--- a/test.js
+++ b/test.js
@@ -43,7 +43,7 @@ assert.equal(JSON.stringify(sortObject({
   "key-10": 1,
 }));
 
-assert.deepStrictEqual(Object.keys(sortObject({
+assert.deepEqual(Object.keys(sortObject({
   b: 1,
   a: 1,
 }, ['a', 'b', 'c', 'd'])), [

--- a/test.js
+++ b/test.js
@@ -42,3 +42,11 @@ assert.equal(JSON.stringify(sortObject({
   "key-3": 1,
   "key-10": 1,
 }));
+
+assert.deepStrictEqual(Object.keys(sortObject({
+  b: 1,
+  a: 1,
+}, ['a', 'b', 'c', 'd'])), [
+  'a',
+  'b'
+])


### PR DESCRIPTION
extra keys in `sortWith` is added to object