### PR TITLE
refactor: drop node<10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '0.12'
-  - v4
+  - '12'
+  - '10'
   - stable
 after_success:
   - npm run semantic-release

--- a/index.js
+++ b/index.js
@@ -1,14 +1,11 @@
-module.exports = function sortObjectByKeyNameList(object, sortWith) {
-  var keys;
-  var sortFn;
+module.exports = function sortObjectByKeyNameList(object, sortWith = []) {
+  let keys = Object.keys(object)
 
   if (typeof sortWith === 'function') {
-    sortFn = sortWith;
+    keys = keys.sort(sortWith)
   } else {
-    keys = sortWith;
+    keys = sortWith.concat(keys.sort())
   }
-  return (keys || []).concat(Object.keys(object).sort(sortFn)).reduce(function(total, key) {
-    total[key] = object[key];
-    return total;
-  }, Object.create(null));
+
+  return Object.fromEntries(keys.map(key => [key, object[key]]))
 }


### PR DESCRIPTION
Not sure about this module target, feel free to close it, if you don't want drop old Node.js support.