### PR TITLE
fix: make this works with require()

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": {
-        "types": "./index.d.ts",
-        "default": "./index.js"
-      }
+      "types": "./index.d.ts",
+      "default": "./index.js"
     }
   },
   "main": "index.js",


### PR DESCRIPTION
Now users can do this:

```js
const { default: sortObjectKeys } = require("sort-object-keys");
```

