### PR TITLE
chore: drop `husky` & other changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,7 @@ jobs:
           node-version: 25
           registry-url: https://registry.npmjs.org/
           cache: npm
-      - run: npm it
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: 25
           registry-url: https://registry.npmjs.org/
           cache: npm
+      - name: Install
+      - run: npm ci
       - name: Lint
         run: npm run lint
       - name: Test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npm run sort && npm run lint && npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
-        "husky": "^9.1.7",
         "prettier": "^3.6.2",
         "sort-package-json": "^3.4.0"
       }
@@ -68,22 +67,6 @@
         "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
       }
     },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -103,6 +86,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "prettier": "^3.6.2",
-        "sort-package-json": "^3.4.0"
+        "prettier-plugin-packagejson": "^2.5.21"
       }
     },
     "node_modules/detect-indent": {
@@ -100,6 +100,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -108,6 +109,24 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-packagejson": {
+      "version": "2.5.21",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.21.tgz",
+      "integrity": "sha512-d9ivsysb1SeRaKDhjf6Hi7jBGnP4TVsh7DeVi8N5HtHJ5vwD7YHcQIuy6jRkr2qGW/VKbrEVDWVMODuqcZuz8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-package-json": "3.5.0"
+      },
+      "peerDependencies": {
+        "prettier": ">= 1.16.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/semver": {
@@ -124,16 +143,16 @@
       }
     },
     "node_modules/sort-object-keys": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
-      "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-2.1.0.tgz",
+      "integrity": "sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/sort-package-json": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.4.0.tgz",
-      "integrity": "sha512-97oFRRMM2/Js4oEA9LJhjyMlde+2ewpZQf53pgue27UkbEXfHJnDzHlUxQ/DWUkzqmp7DFwJp8D+wi/TYeQhpA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.5.0.tgz",
+      "integrity": "sha512-moY4UtptUuP5sPuu9H9dp8xHNel7eP5/Kz/7+90jTvC0IOiPH2LigtRM/aSFSxreaWoToHUVUpEV4a2tAs2oKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -142,7 +161,7 @@
         "git-hooks-list": "^4.0.0",
         "is-plain-obj": "^4.1.0",
         "semver": "^7.7.1",
-        "sort-object-keys": "^1.1.3",
+        "sort-object-keys": "^2.0.0",
         "tinyglobby": "^0.2.12"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -33,15 +33,17 @@
   "scripts": {
     "format": "prettier -w .",
     "lint": "prettier -c .",
-    "sort": "sort-package-json",
     "test": "node --test"
   },
   "prettier": {
+    "plugins": [
+      "prettier-plugin-packagejson"
+    ],
     "semi": false,
     "singleQuote": true
   },
   "devDependencies": {
     "prettier": "^3.6.2",
-    "sort-package-json": "^3.4.0"
+    "prettier-plugin-packagejson": "^2.5.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "scripts": {
     "format": "prettier -w .",
     "lint": "prettier -c .",
-    "prepare": "husky",
     "sort": "sort-package-json",
     "test": "node --test"
   },
@@ -42,7 +41,6 @@
     "singleQuote": true
   },
   "devDependencies": {
-    "husky": "^9.1.7",
     "prettier": "^3.6.2",
     "sort-package-json": "^3.4.0"
   }


### PR DESCRIPTION
- Drop `husky`
- Use `prettier-plugin-packagejson` (uses `sort-package-json` under the hood)
- Update test workflow script

